### PR TITLE
Trim zeroes in parsed inputs

### DIFF
--- a/lib/nested_lines.ex
+++ b/lib/nested_lines.ex
@@ -37,6 +37,7 @@ defmodule NestedLines do
   defp parse_input(line) when is_binary(line) do
     line
     |> String.split(".", trim: true)
+    |> remove_leading_zeros()
     |> convert_to_binary_list([])
   end
 
@@ -51,6 +52,13 @@ defmodule NestedLines do
 
   defp convert_to_binary_list([_head | tail], list) do
     convert_to_binary_list(tail, [0 | list])
+  end
+
+  @spec remove_leading_zeros(list(String.t())) :: list(String.t())
+  defp remove_leading_zeros(line) do
+    line
+    |> Enum.map(&String.replace_leading(&1, "0", ""))
+    |> Enum.reject(&(&1 == ""))
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NestedLines.MixProject do
   def project do
     [
       app: :nested_lines,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/nested_lines_test.exs
+++ b/test/nested_lines_test.exs
@@ -27,6 +27,11 @@ defmodule NestedLinesTest do
       input = NestedLines.new!(["1", "1.1", "1.2"])
       assert %NestedLines{lines: [[1], [0, 1], [0, 1]]} = input
     end
+
+    test "~W(1 1.00 1.01 1.02 1.03) returns [[1], [1], [0, 1], [0, 1], [0, 1]]" do
+      input = NestedLines.new!(["1", "1.00", "1.01", "1.02", "1.03"])
+      assert %NestedLines{lines: [[1], [1], [0, 1], [0, 1], [0, 1]]} = input
+    end
   end
 
   describe "parsing numeric values" do


### PR DESCRIPTION
This change will treat an input of "1.00" as "1", such that "1" followed by "1.00" would be considered two separate lines (not one parent / one child).